### PR TITLE
Suggerisco questo cambiamento

### DIFF
--- a/le-parole-della-pubblica-amministrazione/c.rst
+++ b/le-parole-della-pubblica-amministrazione/c.rst
@@ -52,6 +52,8 @@ C
    
         **Non usare**
            *...per il conseguimento degli obiettivi...*
+        
+        Per approfondire: [regole per un linguaggio breve e semplice](http://guida-linguaggio-pubblica-amministrazione.readthedocs.io/it/latest/suggerimenti-di-scrittura/stile-di-scrittura.html#linguaggio-breve-e-semplice)
 
         |
         

--- a/le-parole-della-pubblica-amministrazione/c.rst
+++ b/le-parole-della-pubblica-amministrazione/c.rst
@@ -44,6 +44,17 @@ C
 
         |
    
+    conseguimento
+        Evita l’uso di questo termine, in particolare nella forma di `nominalizzazione <http://www.treccani.it/enciclopedia/nominalizzazione_%28La-grammatica-italiana%29/>` (ovvero come trasformazione in sostantivo di un verbo).
+   
+       **Usa**
+           *...per raggiungere gli obiettivi...*
+   
+        **Non usare**
+           *...per il conseguimento degli obiettivi...*
+
+        |
+        
    Consiglio dei ministri, Cdm
         Solo la prima iniziale è maiuscola, anche nell’acronimo.
 


### PR DESCRIPTION
conseguimento
Evita l’uso di questo termine, in particolare nella forma di `nominalizzazione <http://www.treccani.it/enciclopedia/nominalizzazione_%28La-grammatica-italiana%29/>` (ovvero come trasformazione in sostantivo di un verbo).
   
**Usa**
*...per raggiungere gli obiettivi...*
   
**Non usare**
*...per il conseguimento degli obiettivi...*