### PR TITLE
Rimossa eccezione per Corte dei conti.

### DIFF
--- a/le-parole-della-pubblica-amministrazione/c.rst
+++ b/le-parole-della-pubblica-amministrazione/c.rst
@@ -80,8 +80,8 @@ conto corrente, c/c
 
      |
 
-Corte 
-     Di regola solo la prima iniziale è maiuscola (es. Corte costituzionale; Corte d’appello; Corte d’assise, Corte di cassazione). Fa eccezione la Corte dei Conti, dove entrambe le iniziali sono maiuscole.
+Corte
+     Di regola solo la prima iniziale è maiuscola (es. Corte costituzionale; Corte d’appello; Corte d’assise, Corte di cassazione).
 
      |
 


### PR DESCRIPTION
L'articolo 100 della Costituzione la riporta come "Corte dei conti".

Fix #22.